### PR TITLE
Add explicit rust toolchain in Action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,14 +8,18 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        default: true
+        override: true
     - name: Install dependencies
       run: sudo apt update && sudo apt install libgtk-3-dev libsqlite3-dev
     - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      run: cargo build --verbose --all --release


### PR DESCRIPTION
In the GitHub action file the Rust toolchain was set up implicit before. Now we have it explicit.